### PR TITLE
propose classmethod decorator to fix subclassing

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -34,12 +34,12 @@ class MoneyPatched(Money):
     def __float__(self):
         return float(self.amount)
 
-    @staticmethod
-    def _patch_to_current_class(money):
+    @classmethod
+    def _patch_to_current_class(cls, money):
         """
         Converts object of type MoneyPatched on the object of type Money.
         """
-        return MoneyPatched(money.amount, money.currency)
+        return cls(money.amount, money.currency)
 
     def __pos__(self):
         return MoneyPatched._patch_to_current_class(


### PR DESCRIPTION
If I want to create a MoneyPatched subclass, then _patch_to_current_class method returns instance of parent class, which in my opinion is a kind of unexpected behavior, because in my derived class I can override some MoneyPatched methods and attributes.
Anyway this patch isn't break any code, I suppose :)
